### PR TITLE
Collapse side panel by default on mobile

### DIFF
--- a/starbucks-mugs.py
+++ b/starbucks-mugs.py
@@ -241,6 +241,17 @@ def visualize(data_path, output_path="index.html"):
         document.getElementById('modal-overlay').style.display = 'block';
         document.getElementById('info-modal').style.display = 'block';
     }}
+
+    // Collapse panel by default on mobile
+    if (window.innerWidth <= 768) {{
+        var panel = document.getElementById('mug-panel');
+        var toggle = document.getElementById('panel-toggle');
+        if (panel && toggle) {{
+            panel.classList.add('collapsed');
+            toggle.classList.add('collapsed');
+            toggle.innerHTML = '&#x2630; Mugs';
+        }}
+    }}
     </script>
     """
 


### PR DESCRIPTION
## Summary
- Side panel now starts collapsed on mobile devices (≤768px width)
- Improves UX by showing the map first on smaller screens

## Test plan
- [ ] Open site on mobile/narrow browser window
- [ ] Verify panel is collapsed by default
- [ ] Verify toggle button works to expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves small-screen UX by default-collapsing the side panel.
> 
> - On load, if `window.innerWidth <= 768`, adds `collapsed` to `#mug-panel` and `#panel-toggle`, and sets toggle text to `"\u2630; Mugs"`
> - Change localized to inline script in `starbucks-mugs.py`; no API or data changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdea7fe5d7b7f2d3b68e4ebfb92da17b40fb5ede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->